### PR TITLE
Finalize pre-commit and post-commit hook

### DIFF
--- a/.githooks/_post_commit/_restore_creds.py
+++ b/.githooks/_post_commit/_restore_creds.py
@@ -1,25 +1,25 @@
 import json
-import re
 from github_utils.constants import GithubConstants, GitConstants
 from github_utils.git_utils import git_config
+from configparser import NoOptionError
 
 
 def main() -> int:
     with open(GithubConstants.GITHUB_CONFIG_FILE.value, mode='r', encoding='utf-8') as config_file:
         config_json = json.load(config_file)
-        curr_api_key = config_json[GithubConstants.API_KEY.value]
-        if re.match(r"\w+", curr_api_key):
-            # this git config custom variable will later be used to restore the apiKey and allow continuous development
-            git_config[GitConstants.API_KEY_CONFIG_PROPERTY] = curr_api_key
-
-            config_json[GithubConstants.API_KEY.value] = '...'
+        try:
+            api_key = git_config[GitConstants.API_KEY_CONFIG_PROPERTY]
+            config_json[GithubConstants.API_KEY.value] = api_key
             with open(GithubConstants.GITHUB_CONFIG_FILE.value, mode='w', encoding='utf-8') as out_config_file:
                 json.dump(config_json, out_config_file, indent=2)
 
-            return 1
+            del git_config[GitConstants.API_KEY_CONFIG_PROPERTY]
+
+        except NoOptionError:  # key was not set in pre-commit hook, probably because api_key was already censored
+            pass
 
     return 0
 
 
 if __name__ == "__main__":
-    exit(main())  # exit with an exit-code indicating whether a change was needed or not
+    exit(main())

--- a/.githooks/_pre_commit/_censor_creds.py
+++ b/.githooks/_pre_commit/_censor_creds.py
@@ -17,4 +17,5 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    print("random change")
     exit(main())  # exit with an exit-code indicating whether a change was needed or not

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,6 @@
+#!/bin/sh
+echo 'restoring censored creds!'
+# script run
+export PATH=$PATH:$(pwd)
+export PYTHONPATH=$(pwd)
+venv/Scripts/python.exe .githooks/_post_commit/_restore_creds.py

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,7 +3,7 @@ echo 'searching for uncensored creds!'
 # script run
 export PATH=$PATH:$(pwd)
 export PYTHONPATH=$(pwd)
-venv/Scripts/python.exe .githooks/_censor_creds.py
+venv/Scripts/python.exe .githooks/_pre_commit/_censor_creds.py
 
 if [ $? -eq 1 ]; then
   # config file was changed so api_key isn't exposed.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,7 +6,7 @@ export PYTHONPATH=$(pwd)
 venv/Scripts/python.exe .githooks/_pre_commit/_censor_creds.py
 
 if [ $? -eq 1 ]; then
-  # config file was changed so api_key isn't exposed.
+  # config file was changed so apiKey isn't exposed.
   # add those changes into the commit
   echo "re-adding config file"
   git add config.json

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-  "api_key": "...",
+  "apiKey": "...",
   "username": "uryyakir"
 }

--- a/github_utils/_github_api.py
+++ b/github_utils/_github_api.py
@@ -4,4 +4,4 @@ from typing import NamedTuple
 
 class GithubConfig(NamedTuple):
     username: str
-    api_key: str
+    apiKey: str

--- a/github_utils/constants.py
+++ b/github_utils/constants.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class GithubConstants(Enum):
+    API_KEY = "apiKey"
+    USERNAME = "username"
+    GITHUB_CONFIG_FILE = "config.json"
+
+
+class GitConstants:
+    CONFIG_LEVEL = "repository"
+    API_KEY_CONFIG_SECTION = "user"
+    API_KEY_CONFIG_PROPERTY = (API_KEY_CONFIG_SECTION, GithubConstants.API_KEY.value)

--- a/github_utils/git_utils.py
+++ b/github_utils/git_utils.py
@@ -1,0 +1,30 @@
+from typing import Tuple
+from git import Repo
+import os
+# local modules
+from github_utils.constants import GitConstants
+
+
+class _Git:
+    def __init__(self, directory: str = os.getcwd()):
+        self._directory = directory
+        self._repo = Repo.init(self._directory)
+        
+        
+class GitConfigHandler(_Git):
+    def __init__(self, *args, **kwargs):
+        super(GitConfigHandler, self).__init__(*args, **kwargs)
+
+    def __getitem__(self, item: Tuple[str, str]) -> str:
+        return self._repo.config_reader(config_level=GitConstants.CONFIG_LEVEL).get_value(*item)
+
+    def __setitem__(self, key: Tuple[str, str], value: str) -> None:
+        self._repo.config_writer(config_level=GitConstants.CONFIG_LEVEL).set_value(*key, value).release()
+        return
+
+    def __delitem__(self, key: Tuple[str, str]) -> None:
+        self._repo.config_writer(config_level=GitConstants.CONFIG_LEVEL).remove_section(GitConstants.API_KEY_CONFIG_SECTION).relase()
+        return
+
+
+git_config = GitConfigHandler()

--- a/github_utils/github_constants.py
+++ b/github_utils/github_constants.py
@@ -1,7 +1,0 @@
-from enum import Enum
-
-
-class GithubConstants(Enum):
-    API_KEY = "api_key"
-    USERNAME = "username"
-    GITHUB_CONFIG_FILE = "config.json"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyGithub
 requests
+gitpython


### PR DESCRIPTION
Finalizing my git hooks:

1. Pre-commit: storing api_key in `.git/config` -> censoring key from `config.json`.
2. Post-commit: reading api_key from `.git/config` -> rewriting actual key to `config.json`, thus allowing proper CD without having to re-insert secrets after every commit.